### PR TITLE
Fixed issue where repeatable groups not displayed on 2nd and later tabs.

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -28,6 +28,7 @@
 
                 form.find(tab.data('fields')).fadeIn('fast', function() {
                     $(this).addClass('cmb-tab-active-item');
+                    $(this).find('.cmb-repeatable-group .cmb-row').addClass('cmb-tab-active-item');
                 });
             });
 


### PR DESCRIPTION
Repeatable groups on every tab past the first were not being displayed. Its a simple fix, just needs to add the `cmb-tab-active-item` class to the `cmb-row` elements of the current active tab.