### PR TITLE
[fix] Fix display problems with single repeatable rows not showing up

### DIFF
--- a/css/tabs.css
+++ b/css/tabs.css
@@ -58,6 +58,10 @@
     display: none;
 }
 
+.cmb-tabs-wrap .cmb2-wrap .cmb-row.cmb-repeat-row {
+    display: block;
+}
+
 /* Vertical tabs */
 .cmb-tabs-wrap.cmb-tabs-vertical {
     -ms-flex-wrap: nowrap;


### PR DESCRIPTION
When using repeatable text fields (not in a group), there was a problem with the text fields not appearing until I pushed the "Add Row" button, but then 2 rows would appear at once. This code should fix that problem - making repeatable rows show up from the start.